### PR TITLE
Java Car Data Login Fix

### DIFF
--- a/java-car-data/car-data-core/src/main/java/com/glicerial/samples/cardatacore/GlobalAuthenticationConfig.java
+++ b/java-car-data/car-data-core/src/main/java/com/glicerial/samples/cardatacore/GlobalAuthenticationConfig.java
@@ -4,9 +4,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
-import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 @Configuration
 public class GlobalAuthenticationConfig extends GlobalAuthenticationConfigurerAdapter {
@@ -18,7 +18,9 @@ public class GlobalAuthenticationConfig extends GlobalAuthenticationConfigurerAd
 
     @Bean
     UserDetailsService userDetailsService() {
-        return (username) -> new User("user", "password", true, true, true, true,
-                                        AuthorityUtils.createAuthorityList("USER", "write"));
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        manager.createUser(User.withUsername("user").password("password").authorities("USER", "write").build());
+
+        return manager;
     }
 }


### PR DESCRIPTION
- Corrected authentication of default user to correctly validate against
  username of "user"
- Previously the authentication would always validate as default user as
  long as password was "password", not taking the username into account